### PR TITLE
Improve package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     ],
     "preferUnplugged": true,
     "scripts": {
-        "build": "cargo build-wasi --release && mv target/wasm32-wasi/release/swc_plugin_nullstack.wasm ./dist/swc-plugin-nullstack.wasm",
-        "test": "cargo test"
+        "build": "npm run update-wasi && cargo build-wasi --release && npm run cpy-to-dist",
+        "test": "cargo test",
+        "update-wasi": "rustup target add wasm32-wasi",
+        "cpy-to-dist": "npx -y cpy-cli target/wasm32-wasi/release/swc_plugin_nullstack.wasm ./dist --flat --rename=swc-plugin-nullstack.wasm"
     }
 }


### PR DESCRIPTION
`build` script now does:
- `npm run update-wasi`: Update or installs target `wasm32-wasi`
- Builds into wasm file
- `npm run cpy-to-dist`: Same as current `mv ...` but cross environment using package [`cpy-cli`](https://npmjs.com/package/cpy-cli) (could be added to project dependencies in the future)